### PR TITLE
Add permission for hypershift deployment controller to operate managed cluster

### DIFF
--- a/templates/hypershiftDeployment_clusterrole.yaml
+++ b/templates/hypershiftDeployment_clusterrole.yaml
@@ -74,3 +74,28 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+- apiGroups:
+  - register.open-cluster-management.io
+  resources:
+  - managedclusters/accept
+  verbs:
+  - update
+


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

Based on https://github.com/stolostron/hypershift-deployment-controller/pull/32, we need to add permission for hypershift deployment controller to operate managed cluster