### PR TITLE
Update permission for hypershift addon manager

### DIFF
--- a/templates/hypershift-addon-manager-deployment.yaml
+++ b/templates/hypershift-addon-manager-deployment.yaml
@@ -64,7 +64,6 @@ spec:
       hostIPC: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
       terminationGracePeriodSeconds: 30
       containers:
         - name: {{ .Values.hypershiftAddonMgrOperator.name }}

--- a/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/templates/hypershift-addon-manager_clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - secrets
   - configmaps
+  - events
   verbs:
   - create
   - deletecollection
@@ -110,3 +111,4 @@ rules:
   - get
   - list
   - watch
+

--- a/templates/hypershift-addon-manager_clusterrole.yaml
+++ b/templates/hypershift-addon-manager_clusterrole.yaml
@@ -32,6 +32,12 @@ rules:
 - apiGroups:
   - addon.open-cluster-management.io
   resources:
+  - managedclusteraddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
   - managedclusteraddons/status
   verbs:
   - create
@@ -85,6 +91,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - kubernetes.io/kube-apiserver-client
+  verbs:
+  - approve
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

- delete runAsRoot: 1001 to fix:
```
    message: 'pods "hypershift-addon-manager-5c95fc65c9-" is forbidden: unable to
      validate against any security context constraint: [provider "anyuid": Forbidden:
      not usable by user or serviceaccount, spec.containers[0].securityContext.runAsUser:
      Invalid value: 1001: must be in the ranges: [1000810000, 1000819999], provider
      "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid":
      Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler":
      Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden:
      not usable by user or serviceaccount, provider "hostaccess": Forbidden: not
      usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable
      by user or serviceaccount, provider "privileged": Forbidden: not usable by user
      or serviceaccount]
```

- add events permission for addon manager
- add csr sign & managed cluster addon finalizer permission to fix
```
I0314 03:40:35.208461       1 event.go:285] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"default", Name:"default", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-hypershift-addon-deploy: manifestworks.work.open-cluster-management.io "addon-hypershift-addon-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0314 03:40:35.212674       1 base_controller.go:270] "CSRApprovingController" controller failed to sync "addon-local-cluster-hypershift-addon-nrd5s", err: certificatesigningrequests.certificates.k8s.io "addon-local-cluster-hypershift-addon-nrd5s" is forbidden: user not permitted to approve requests with signerName "kubernetes.io/kube-apiserver-client"
```